### PR TITLE
修复暗模式下侧边栏当前章节文字被亮绿色背景遮挡

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -723,6 +723,11 @@ button {
   background: var(--wb-acid);
 }
 
+.dark .VPSidebarItem.is-active > .item .link {
+  color: var(--wb-ink) !important;
+  background: var(--wb-acid-soft);
+}
+
 .VPSidebarItem.is-active > .item .link::before {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## 改动内容 / What changed

- 修复 `docs/.vitepress/theme/style.css` 中暗模式下侧边栏当前章节高亮的视觉问题
- 新增 `.dark .VPSidebarItem.is-active > .item .link` 变体，覆盖暗模式下的背景色和文字色

## 为什么需要 / Why

暗模式下，`.VPSidebarItem.is-active` 仍使用 `var(--wb-acid)` 亮绿（#d8f238）作为背景，配合硬编码的 `color: #11130e` 深色文字。亮绿色在深色背景中过于刺眼，文字虽然颜色对比足够，但视觉上几乎被"灼烧"的高亮背景吞没，表现为"文字被遮住"。

修复后：
- 亮模式：保持原样（亮绿背景 + 深色文字）
- 暗模式：背景改用 `var(--wb-acid-soft)` 深橄榄色（#2b3218），文字改用 `var(--wb-ink)` 浅色（#f3f5ed），既保留高亮识别度，又解决可读性

## 验证方式 / Validation

- [x] `npm run docs:build`（build complete in 23.37s，零错误）
- [x] 已检查相关链接、图片和视频
- [x] 已检查桌面和移动端可读性

## 产品事实更新 / Product fact updates

- [x] 否 / No