### PR TITLE
fix 超链接样式错乱

### DIFF
--- a/docs/bluebook/第一篇 使用手册：先把 WorkBuddy 用起来/第 2 章 WorkBuddy的下载、安装、登录与更新/index.md
+++ b/docs/bluebook/第一篇 使用手册：先把 WorkBuddy 用起来/第 2 章 WorkBuddy的下载、安装、登录与更新/index.md
@@ -2,7 +2,7 @@
 
 ## WorkBuddy下载
 
-下载WorkBuddy，点击官方地址（https://www.codebuddy.cn/work/），选择WorkBuddy，点击“下载WorkBuddy”即可下载。
+下载WorkBuddy，点击官方地址（[https://www.codebuddy.cn](https://www.codebuddy.cn/work)），选择WorkBuddy，点击“下载WorkBuddy”即可下载。
 
 ![](assets/001_image_GGeabJkE2o.png)
 


### PR DESCRIPTION
## 为什么需要 / Why
超链接样式错乱

- 改之前
<img width="1019" height="444" alt="image" src="https://github.com/user-attachments/assets/fc21fa07-e741-400b-bb95-a0a08a074342" />

- 改之后
<img width="995" height="405" alt="image" src="https://github.com/user-attachments/assets/6ad6d1c2-a9c8-4af2-982a-3078004da2fd" />

并且之前跳转的链接也是错误的(但能用)
<img width="889" height="416" alt="image" src="https://github.com/user-attachments/assets/b3e13fa3-eec0-4f14-91b1-bc7bcf925ff5" />


