### PR TITLE
docs: add OrcaRouter as a named external API provider in Chapter 9

### DIFF
--- a/docs/bluebook/第一篇 使用手册：先把 WorkBuddy 用起来/第 9 章 如何接入外部 API/index.md
+++ b/docs/bluebook/第一篇 使用手册：先把 WorkBuddy 用起来/第 9 章 如何接入外部 API/index.md
@@ -27,3 +27,5 @@ WorkBuddy支持接入其他 LLM 的 API，以及 Coding Plan、Token Plan 等套
 或者接入本地ollama模型，需先本地启动 Ollama（默认端口 11434，OpenAI 兼容接口），本地模型优势为数据不出本机、可离线、零 Token 成本。
 
 ![](assets/006_image_BSnBbYupuo.png)
+
+也可以接入 [OrcaRouter](https://www.orcarouter.ai) 聚合网关，添加模型时输入你的 OrcaRouter API Key（以 `sk-orca-` 开头）即可。OrcaRouter 是 OpenAI 兼容的 AI 网关，在一个接口下聚合多家模型（如 `openai/gpt-5.5`、`anthropic/claude-opus-4.8`、`google/gemini-3.5-flash` 等），并支持自适应路由、自动故障转移和零加价推理。默认模型可以选 `orcarouter/auto`，它会根据任务自动选择最合适的模型。官网：[https://www.orcarouter.ai](https://www.orcarouter.ai)


### PR DESCRIPTION
## What changed

- Add [OrcaRouter](https://www.orcarouter.ai) as a named external API provider in Chapter 9 ("Connecting external APIs"), right after the existing DeepSeek and local Ollama examples.

## Why

The WorkBuddy Bluebook is a task-driven field guide that walks readers from their first task to an AI team, and Chapter 9 is where readers connect their own LLM API when they don't have plan credits. Today it shows DeepSeek (enter just the API key) and a local Ollama model as examples. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models - but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider in this chapter means readers can use that stack directly through the same "Add model" screen, instead of treating OrcaRouter as an anonymous custom base URL.

The new paragraph follows the exact shape of the existing DeepSeek/Ollama examples (what to type in the model dialog, one-line product description), so it fits the chapter without introducing new UI steps. It also runs gateway-level, zero-trust security for AI agents on the same endpoint - screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Validation

- `npm run docs:build` - production build completed
- `npm test` - 23 tests passed
- Live API check against `https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` returned HTTP 200

## Product fact updates

- Yes - provider endpoint and model IDs were verified via a live API call on 2026-08-31.

---

I'm an engineer on the OrcaRouter team. Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
