### PR TITLE
docs: link the Awesome WorkBuddy directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 GitHub 适合了解项目和参与贡献；真正阅读蓝皮书时，网站体验更完整。
 
+需要横向查找更多 Skills、MCP、连接器、工具和社区项目时，可以使用独立维护的 [Awesome WorkBuddy](https://github.com/sandbaseai/awesome-workbuddy) 双语目录；其中的可执行资源会标注许可证、凭据、文件权限与数据流边界，使用前仍需复核对应上游项目。
+
 ## 你会在这里看到什么
 
 | 部分 | 内容 |

--- a/README_en.md
+++ b/README_en.md
@@ -23,6 +23,8 @@ The recommended reading experience is **[workbuddy.homes](https://workbuddy.home
 
 The book is currently written primarily in Simplified Chinese. English contributions and translation proposals are welcome.
 
+For broader discovery across Skills, MCP servers, connectors, tools, and community projects, see the independently maintained bilingual [Awesome WorkBuddy](https://github.com/sandbaseai/awesome-workbuddy) directory. Its executable-resource entries document license, credential, file-permission, and data-flow boundaries; still verify each upstream project before use.
+
 ## What Is Inside
 
 | Section | Topics |


### PR DESCRIPTION
Adds a concise bilingual pointer from the Bluebook README to the complementary Awesome WorkBuddy directory.

The Bluebook remains the task-driven learning path; the linked directory helps readers discover 98 cross-repository Skills, MCP servers, integrations, tools, and community projects with explicit license, credential, file-permission, and data-flow notes. The text identifies it as independently maintained and tells readers to verify upstream projects.

Verification:
- `git diff --check`
- `npm test` — 23 tests pass
- `npm run docs:build` — VitePress build and sitemap complete on Node 24.19.0
